### PR TITLE
Updated to 1.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a Minecraft mod that overlays a timer on the Vanilla status effect HUD icons.
 
-This mod requires Minecraft 1.16.5, 1.17 or 1.17.1 and the Fabric loader.
+This mod requires Minecraft 1.16.5, 1.17.x or 1.18.1 and the Fabric loader.
 
 This mod overlays the number of seconds left of the status effect, or the number of minutes (followed by "m") if it is more than 60 seconds, on the vanilla status effect indicator. That's it. This is a very minimalistic mod. No settings are required nor provided.
 
@@ -19,7 +19,7 @@ This is what it looks like when you are using the mod.
 
 ## Download
 
-You can download the latest version here: [statuseffecttimer-1.0.3.jar](https://github.com/magicus/statuseffecttimer/releases/download/v1.0.3/statuseffecttimer-1.0.3.jar)
+You can download the latest version here: [statuseffecttimer-1.0.4.jar](https://github.com/magicus/statuseffecttimer/releases/download/v1.0.4/statuseffecttimer-1.0.4.jar)
 
 ## Installation
 
@@ -30,5 +30,5 @@ Install this as you would any other Fabric mod. (Personally, I recommend MultiMC
 
 Do you have any problems with the mod? Please open an issue here on Github.
 
-Currently only Minecraft versions 1.16.5 to 1.17.1 are supported, but it would probably be trivial to add support for other versions.
+Currently only Minecraft versions 1.16.5 to 1.18.1 are supported, but it would probably be trivial to add support for other versions.
 If you want support for another version, please open an issue and state the requested version.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.10-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.17.1
-yarn_mappings=1.17.1+build.14
-loader_version=0.11.6
+minecraft_version=1.18.1
+yarn_mappings=1.18.1+build.2
+loader_version=0.12.11
 
 # Mod Properties
-mod_version = 1.0.3
+mod_version = 1.0.4
 maven_group = se.icus.mag
 archives_base_name = statuseffecttimer
 
 # Dependencies
 # Fabric api
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api (or https://fabricmc.net/versions.html)
-fabric_version=0.37.0+1.17
+fabric_version=0.44.0+1.18

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,6 @@
 
   "depends": {
     "fabricloader": ">=0.7.4",
-    "minecraft": "1.17.x"
+    "minecraft": "1.18.x"
   }
 }


### PR DESCRIPTION
I'm new to all this, but I ran `./gradlew migrateMappings --mappings "1.18.1+build.2"` which changed nothing, and then edited a few files to point to newer versions. When I build, (On Arch Linux with gradle 7.3.1-1 and java-16-graalvm) I get a bunch of warnings about the compiler needing upgrading, but it does succeed and I've tested it on 1.18.1.
Let me know if anything needs fixing