### PR TITLE
Attempt to update to Minecraft 1.19.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.19
-yarn_mappings=1.19+build.2
-loader_version=0.14.7
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.2
+loader_version=0.14.21
 
 # Mod Properties
 mod_version = 1.1.1+1.19
@@ -14,4 +14,4 @@ archives_base_name = statuseffecttimer
 
 # Dependencies
 # Fabric api
-fabric_version=0.56.0+1.19
+fabric_version=0.85.0+1.19.4

--- a/src/main/java/se/icus/mag/statuseffecttimer/mixin/StatusEffectTimerMixin.java
+++ b/src/main/java/se/icus/mag/statuseffecttimer/mixin/StatusEffectTimerMixin.java
@@ -86,7 +86,7 @@ public abstract class StatusEffectTimerMixin extends DrawableHelper {
 	@Nullable
 	private String getAmplifierAsString(StatusEffectInstance statusEffectInstance) {
 		int ampl = statusEffectInstance.getAmplifier();
-		String k = String.format("potion.potency.%d", ampl);
+		String k = String.format("enchantment.level.%d", ampl + 1);
 		if (ampl > 0) {
 			if (I18n.hasTranslation(k)) {
 				return I18n.translate(k);

--- a/src/main/java/se/icus/mag/statuseffecttimer/mixin/StatusEffectTimerMixin.java
+++ b/src/main/java/se/icus/mag/statuseffecttimer/mixin/StatusEffectTimerMixin.java
@@ -18,6 +18,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Collection;
@@ -28,6 +29,16 @@ import java.util.Collection;
 public abstract class StatusEffectTimerMixin extends DrawableHelper {
 	@Shadow @Final
 	private MinecraftClient client;
+
+	@Redirect(method = "renderStatusEffectOverlay",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/effect/StatusEffectInstance;shouldShowIcon()Z"))
+	private boolean display(StatusEffectInstance instance) {
+		return shouldDisplay(instance);
+	}
+
+	private boolean shouldDisplay(StatusEffectInstance instance) {
+		return true;
+	}
 
 	@Inject(method = "renderStatusEffectOverlay", at = @At("TAIL"))
 	private void renderDurationOverlay(MatrixStack matrices, CallbackInfo c) {
@@ -40,7 +51,7 @@ public abstract class StatusEffectTimerMixin extends DrawableHelper {
 			int nonBeneficialCount = 0;
 			for (StatusEffectInstance statusEffectInstance : Ordering.natural().reverse().sortedCopy(collection)) {
 				StatusEffect statusEffect = statusEffectInstance.getEffectType();
-				if (statusEffectInstance.shouldShowIcon()) {
+				if (shouldDisplay(statusEffectInstance)) {
 					int x = this.client.getWindow().getScaledWidth();
 					int y = 1;
 

--- a/src/main/java/se/icus/mag/statuseffecttimer/mixin/StatusEffectTimerMixin.java
+++ b/src/main/java/se/icus/mag/statuseffecttimer/mixin/StatusEffectTimerMixin.java
@@ -69,13 +69,11 @@ public abstract class StatusEffectTimerMixin extends DrawableHelper {
 					}
 
 					String duration = getDurationAsString(statusEffectInstance);
-					int durationLength = client.textRenderer.getWidth(duration);
-					drawStringWithShadow(matrices, client.textRenderer, duration, x + 13 - (durationLength / 2), y + 14, 0x99FFFFFF);
+					drawCenteredTextWithShadow(matrices, client.textRenderer, duration, x + 13, y + 14, 0x99FFFFFF);
 
 					String amplifierString = getAmplifierAsString(statusEffectInstance);
 					if (amplifierString != null) {
-						int amplifierLength = client.textRenderer.getWidth(amplifierString);
-						drawStringWithShadow(matrices, client.textRenderer, amplifierString, x + 22 - amplifierLength, y + 3, 0x99FFFFFF);
+						drawCenteredTextWithShadow(matrices, client.textRenderer, amplifierString, x + 19, y + 3, 0x99FFFFFF);
 					}
 				}
 			}
@@ -84,12 +82,20 @@ public abstract class StatusEffectTimerMixin extends DrawableHelper {
 
 	@NotNull
 	private String getDurationAsString(StatusEffectInstance statusEffectInstance) {
+		if (statusEffectInstance.isInfinite()) {
+			return I18n.translate("effect.duration.infinite");
+		}
 		int ticks = MathHelper.floor((float) statusEffectInstance.getDuration());
 		int seconds = ticks / 20;
+		int hours = seconds / 3600;
+		double minutes = seconds / 60.0;
 		if (seconds >= 3600) {
-			return String.format("%dh", seconds / 3600);
+			if (hours < 1000) {
+				return String.format("%dh", hours);
+			}
+			return "****";
 		} else if (seconds >= 60) {
-			return String.format("%.1fm", (float) (seconds / 60.0));
+			return String.format("%.1fm", (float) minutes);
 		}
 		return String.format("%ds", seconds);
 	}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,6 @@
 
   "depends": {
     "fabricloader": ">=0.7.4",
-    "minecraft": "~1.19"
+    "minecraft": "1.19.4"
   }
 }


### PR DESCRIPTION
**Initial comment:**

Hello. I think displaying the longer remaining potion duration <s>(than 32147 ticks or whatever)</s> could be better. Higher versions of Minecraft Java displays long potion duration instead of "\*\*:\*\*" in inventory screen.
![duration](https://github.com/magicus/statuseffecttimer/assets/92579614/dfab0ed9-adb7-479b-bd3f-fa48a9b2dcbc)
![romannumberals10](https://github.com/magicus/statuseffecttimer/assets/92579614/cb9d43ab-f074-42ce-98cc-ed1884297d83)

**Update on July 10th:**

I made some changes so to function on Minecraft 1.19.4. Looks good.

![1.19.4](https://github.com/magicus/statuseffecttimer/assets/92579614/3423ce9f-9db8-4730-ba36-77eb1f5e805e)

Closes https://github.com/magicus/statuseffecttimer/issues/14
Closes https://github.com/magicus/statuseffecttimer/issues/16